### PR TITLE
S3plugin

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -38,11 +38,8 @@ repositories {
 dependencies {
     compile "com.google.guava:guava:19.0"
     compile "javax.mail:mail:1.4.7"
-    compile("org.ow2.proactive:scheduler-api:$projectVersion") {
-        exclude module: "org.slf4j"
-	exclude module: "vfs-s3"
-    }
-
+    compileOnly "org.ow2.proactive:scheduler-api:$projectVersion"
+    
     testCompile "com.google.truth:truth:0.28"
     testCompile "junit:junit:4.12"
     testCompile 'org.mockito:mockito-core:1.10.19'

--- a/build.gradle
+++ b/build.gradle
@@ -38,7 +38,10 @@ repositories {
 dependencies {
     compile "com.google.guava:guava:19.0"
     compile "javax.mail:mail:1.4.7"
-    compileOnly "org.ow2.proactive:scheduler-api:$projectVersion"
+    compileOnly("org.ow2.proactive:scheduler-api:$projectVersion"){
+        exclude module: "org.slf4j"
+        exclude module: "vfs-s3"
+    }
     
     testCompile "com.google.truth:truth:0.28"
     testCompile "junit:junit:4.12"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
-#Tue, 30 Aug 2016 15:41:50 +0200
-projectVersion=7.17.0-SNAPSHOT
+#Tue, 06 Sep 2016 17:01:58 +0200
+projectVersion=7.18.0-SNAPSHOT

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,2 @@
 #Fri, 19 Aug 2016 12:03:02 +0200
-projectVersion=7.16.0-SNAPSHOT
+projectVersion=7.18.0-SNAPSHOT


### PR DESCRIPTION
Moved scheduler-api dependency to compileOnly in order to avoid vfs-s3 dependency duplication problem in the release
