### PR TITLE
Allow setting unspecified (not declared in the class) smtp properties

### DIFF
--- a/src/main/java/org/ow2/proactive/addons/email/EmailSender.java
+++ b/src/main/java/org/ow2/proactive/addons/email/EmailSender.java
@@ -130,10 +130,6 @@ public class EmailSender {
         checkInstanceFieldsConsistency();
     }
 
-    private void setProperties(Properties properties) {
-        this.properties = properties;
-    }
-
     public void sendPlainTextEmailWithAttachment() {
         Properties props = buildSmtpConfiguration();
         Session session = Session.getDefaultInstance(props, buildAuthenticator());

--- a/src/main/java/org/ow2/proactive/addons/email/EmailSender.java
+++ b/src/main/java/org/ow2/proactive/addons/email/EmailSender.java
@@ -686,7 +686,6 @@ public class EmailSender {
         }
 
         public void withProperties(Map<?, ?> properties) {
-            this.properties = new Properties();
             this.properties.putAll(properties);
         }
 

--- a/src/test/java/org/ow2/proactive/addons/email/EmailSenderBuilderTest.java
+++ b/src/test/java/org/ow2/proactive/addons/email/EmailSenderBuilderTest.java
@@ -48,6 +48,12 @@ public class EmailSenderBuilderTest {
 
     private static URI EMAIL_CONFIGURATION;
 
+    private static final String EXTRA_PROPERTY_MAIL_SMTP_SSL_ENABLE = "mail.smtp.ssl.enable";
+
+    private static final String EXTRA_PROPERTY_MAIL_SMTP_CONNECTIONTIMEOUT = "mail.smtp.connectiontimeout";
+
+    private static final String EXTRA_PROPERTY_MAIL_SMTP_CIPHERSUITES = "mail.smtp.ssl.ciphersuites";
+
     @BeforeClass
     public static void setJobDescriptorcUri() throws Exception {
         EMAIL_CONFIGURATION = EmailSenderBuilderTest.class.getResource("/org/ow2/proactive/addons/email/email.properties")
@@ -77,6 +83,7 @@ public class EmailSenderBuilderTest {
         assertThat(builder.getTrustSsl()).isEqualTo("*");
         assertThat(builder.getFileToAttach()).isNull();
         assertThat(builder.getFileName()).isEqualTo("attachment.txt");
+        assertThat(builder.getProperties()).isEmpty();
     }
 
     @Test
@@ -121,6 +128,7 @@ public class EmailSenderBuilderTest {
         assertThat(builder.getTrustSsl()).isEqualTo("all");
         assertThat(builder.getFileToAttach()).isEqualTo("file_path");
         assertThat(builder.getFileName()).isEqualTo("file_name");
+        assertThat(builder.getProperties()).isEmpty();
     }
 
     @Test
@@ -144,4 +152,87 @@ public class EmailSenderBuilderTest {
         assertThat(builder.isStartTlsEnabled()).isTrue();
     }
 
+    @Test
+    public void testExtraPropertiesAreSaved() {
+        ImmutableMap.Builder<String, Serializable> config = ImmutableMap.builder();
+
+        config.put(EmailSender.ARG_FROM, "from");
+        config.put(EmailSender.ARG_RECIPIENTS, "a,b,c");
+        config.put(EmailSender.ARG_CC, "d, e");
+        config.put(EmailSender.ARG_BCC, "f, g,h, i");
+        config.put(EmailSender.ARG_SUBJECT, "subject");
+        config.put(EmailSender.ARG_BODY, "body");
+        config.put(EmailSender.ARG_FILETOATTACH, "file_path");
+        config.put(EmailSender.ARG_FILENAME, "file_name");
+
+        config.put(EmailSender.PROPERTY_MAIL_DEBUG, "true");
+        config.put(EmailSender.PROPERTY_MAIL_SMTP_HOST, "smtp.host.com");
+        config.put(EmailSender.PROPERTY_MAIL_SMTP_PORT, "25");
+        config.put(EmailSender.PROPERTY_MAIL_SMTP_USERNAME, "username");
+        config.put(EmailSender.PROPERTY_MAIL_SMTP_PASSWORD, "password");
+        config.put(EmailSender.PROPERTY_MAIL_SMTP_AUTH, "true");
+        config.put(EmailSender.PROPERTY_MAIL_SMTP_STARTTLS_ENABLE, "true");
+        config.put(EmailSender.PROPERTY_MAIL_SMTP_SSL_TRUST, "all");
+        config.put(EXTRA_PROPERTY_MAIL_SMTP_SSL_ENABLE, "true");
+        config.put(EXTRA_PROPERTY_MAIL_SMTP_CONNECTIONTIMEOUT, "120000");
+
+        EmailSender.Builder builder = new EmailSender.Builder(config.build());
+
+        assertThat(builder.getFrom()).isEqualTo("from");
+        assertThat(builder.getRecipients()).containsExactly("a", "b", "c");
+        assertThat(builder.getCc()).containsExactly("d", "e");
+        assertThat(builder.getBcc()).containsExactly("f", "g", "h", "i");
+        assertThat(builder.getSubject()).isEqualTo("subject");
+        assertThat(builder.getBody()).isEqualTo("body");
+
+        assertThat(builder.isDebugEnabled()).isTrue();
+        assertThat(builder.getHost()).isEqualTo("smtp.host.com");
+        assertThat(builder.getPort()).isEqualTo(25);
+        assertThat(builder.getUsername()).isEqualTo("username");
+        assertThat(builder.getPassword()).isEqualTo("password");
+        assertThat(builder.isAuthEnabled()).isTrue();
+        assertThat(builder.isStartTlsEnabled()).isTrue();
+        assertThat(builder.getTrustSsl()).isEqualTo("all");
+        assertThat(builder.getFileToAttach()).isEqualTo("file_path");
+        assertThat(builder.getFileName()).isEqualTo("file_name");
+        assertThat(builder.getProperties().size()).isEqualTo(2);
+    }
+
+    @Test
+    public void testExtraPropertiesWitherOverridesValues() {
+        ImmutableMap.Builder<String, Serializable> config = ImmutableMap.builder();
+
+        config.put(EmailSender.ARG_FROM, "from");
+        config.put(EmailSender.ARG_RECIPIENTS, "a,b,c");
+        config.put(EmailSender.ARG_CC, "d, e");
+        config.put(EmailSender.ARG_BCC, "f, g,h, i");
+        config.put(EmailSender.ARG_SUBJECT, "subject");
+        config.put(EmailSender.ARG_BODY, "body");
+        config.put(EmailSender.ARG_FILETOATTACH, "file_path");
+        config.put(EmailSender.ARG_FILENAME, "file_name");
+
+        config.put(EmailSender.PROPERTY_MAIL_DEBUG, "true");
+        config.put(EmailSender.PROPERTY_MAIL_SMTP_HOST, "smtp.host.com");
+        config.put(EmailSender.PROPERTY_MAIL_SMTP_PORT, "25");
+        config.put(EmailSender.PROPERTY_MAIL_SMTP_USERNAME, "username");
+        config.put(EmailSender.PROPERTY_MAIL_SMTP_PASSWORD, "password");
+        config.put(EmailSender.PROPERTY_MAIL_SMTP_AUTH, "true");
+        config.put(EmailSender.PROPERTY_MAIL_SMTP_STARTTLS_ENABLE, "true");
+        config.put(EmailSender.PROPERTY_MAIL_SMTP_SSL_TRUST, "all");
+
+        config.put(EXTRA_PROPERTY_MAIL_SMTP_CONNECTIONTIMEOUT, "120000");
+
+        EmailSender.Builder builder = new EmailSender.Builder(config.build());
+        assertThat(builder.getProperties().size()).isEqualTo(1);
+        assertThat(builder.getProperties().get(EXTRA_PROPERTY_MAIL_SMTP_CONNECTIONTIMEOUT)).isNotNull();
+
+        ImmutableMap.Builder<String, Serializable> props = ImmutableMap.builder();
+        props.put(EXTRA_PROPERTY_MAIL_SMTP_SSL_ENABLE, "from");
+        props.put(EXTRA_PROPERTY_MAIL_SMTP_CIPHERSUITES, "DHE_RSA_AES256_SHA256");
+        ImmutableMap resultProperties = props.build();
+        // Override the two previous properties
+        builder.withProperties(resultProperties);
+
+        assertThat(builder.getProperties()).containsExactlyEntriesIn(resultProperties);
+    }
 }

--- a/src/test/java/org/ow2/proactive/addons/email/EmailSenderBuilderTest.java
+++ b/src/test/java/org/ow2/proactive/addons/email/EmailSenderBuilderTest.java
@@ -32,6 +32,8 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.net.URI;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Properties;
 
 import org.junit.Assert;
@@ -199,7 +201,7 @@ public class EmailSenderBuilderTest {
     }
 
     @Test
-    public void testExtraPropertiesWitherOverridesValues() {
+    public void testExtraPropertiesWitherDoesNotReinitialize() {
         ImmutableMap.Builder<String, Serializable> config = ImmutableMap.builder();
 
         config.put(EmailSender.ARG_FROM, "from");
@@ -233,6 +235,11 @@ public class EmailSenderBuilderTest {
         // Override the two previous properties
         builder.withProperties(resultProperties);
 
-        assertThat(builder.getProperties()).containsExactlyEntriesIn(resultProperties);
+        ImmutableMap.Builder<String, Serializable> allExtraProperties = ImmutableMap.builder();
+        allExtraProperties.put(EXTRA_PROPERTY_MAIL_SMTP_SSL_ENABLE, "from");
+        allExtraProperties.put(EXTRA_PROPERTY_MAIL_SMTP_CIPHERSUITES, "DHE_RSA_AES256_SHA256");
+        allExtraProperties.put(EXTRA_PROPERTY_MAIL_SMTP_CONNECTIONTIMEOUT, "120000");
+
+        assertThat(builder.getProperties()).containsExactlyEntriesIn(allExtraProperties.build());
     }
 }

--- a/src/test/java/org/ow2/proactive/addons/email/EmailSenderBuilderTest.java
+++ b/src/test/java/org/ow2/proactive/addons/email/EmailSenderBuilderTest.java
@@ -54,8 +54,6 @@ public class EmailSenderBuilderTest {
 
     private static final String EXTRA_PROPERTY_MAIL_SMTP_CONNECTIONTIMEOUT = "mail.smtp.connectiontimeout";
 
-    private static final String EXTRA_PROPERTY_MAIL_SMTP_CIPHERSUITES = "mail.smtp.ssl.ciphersuites";
-
     @BeforeClass
     public static void setJobDescriptorcUri() throws Exception {
         EMAIL_CONFIGURATION = EmailSenderBuilderTest.class.getResource("/org/ow2/proactive/addons/email/email.properties")
@@ -85,7 +83,6 @@ public class EmailSenderBuilderTest {
         assertThat(builder.getTrustSsl()).isEqualTo("*");
         assertThat(builder.getFileToAttach()).isNull();
         assertThat(builder.getFileName()).isEqualTo("attachment.txt");
-        assertThat(builder.getProperties()).isEmpty();
     }
 
     @Test
@@ -130,7 +127,6 @@ public class EmailSenderBuilderTest {
         assertThat(builder.getTrustSsl()).isEqualTo("all");
         assertThat(builder.getFileToAttach()).isEqualTo("file_path");
         assertThat(builder.getFileName()).isEqualTo("file_name");
-        assertThat(builder.getProperties()).isEmpty();
     }
 
     @Test
@@ -155,7 +151,7 @@ public class EmailSenderBuilderTest {
     }
 
     @Test
-    public void testExtraPropertiesAreSaved() {
+    public void testExtraPropertiesAreSavedUsingWither() {
         ImmutableMap.Builder<String, Serializable> config = ImmutableMap.builder();
 
         config.put(EmailSender.ARG_FROM, "from");
@@ -175,8 +171,6 @@ public class EmailSenderBuilderTest {
         config.put(EmailSender.PROPERTY_MAIL_SMTP_AUTH, "true");
         config.put(EmailSender.PROPERTY_MAIL_SMTP_STARTTLS_ENABLE, "true");
         config.put(EmailSender.PROPERTY_MAIL_SMTP_SSL_TRUST, "all");
-        config.put(EXTRA_PROPERTY_MAIL_SMTP_SSL_ENABLE, "true");
-        config.put(EXTRA_PROPERTY_MAIL_SMTP_CONNECTIONTIMEOUT, "120000");
 
         EmailSender.Builder builder = new EmailSender.Builder(config.build());
 
@@ -197,49 +191,15 @@ public class EmailSenderBuilderTest {
         assertThat(builder.getTrustSsl()).isEqualTo("all");
         assertThat(builder.getFileToAttach()).isEqualTo("file_path");
         assertThat(builder.getFileName()).isEqualTo("file_name");
-        assertThat(builder.getProperties().size()).isEqualTo(2);
-    }
+        assertThat(builder.getProperties().size()).isEqualTo(8);
 
-    @Test
-    public void testExtraPropertiesWitherDoesNotReinitialize() {
-        ImmutableMap.Builder<String, Serializable> config = ImmutableMap.builder();
+        ImmutableMap.Builder<String, Serializable> extraProps = ImmutableMap.builder();
+        extraProps.put(EXTRA_PROPERTY_MAIL_SMTP_SSL_ENABLE, "true");
+        extraProps.put(EXTRA_PROPERTY_MAIL_SMTP_CONNECTIONTIMEOUT, "120000");
+        builder.withProperties(extraProps.build());
 
-        config.put(EmailSender.ARG_FROM, "from");
-        config.put(EmailSender.ARG_RECIPIENTS, "a,b,c");
-        config.put(EmailSender.ARG_CC, "d, e");
-        config.put(EmailSender.ARG_BCC, "f, g,h, i");
-        config.put(EmailSender.ARG_SUBJECT, "subject");
-        config.put(EmailSender.ARG_BODY, "body");
-        config.put(EmailSender.ARG_FILETOATTACH, "file_path");
-        config.put(EmailSender.ARG_FILENAME, "file_name");
-
-        config.put(EmailSender.PROPERTY_MAIL_DEBUG, "true");
-        config.put(EmailSender.PROPERTY_MAIL_SMTP_HOST, "smtp.host.com");
-        config.put(EmailSender.PROPERTY_MAIL_SMTP_PORT, "25");
-        config.put(EmailSender.PROPERTY_MAIL_SMTP_USERNAME, "username");
-        config.put(EmailSender.PROPERTY_MAIL_SMTP_PASSWORD, "password");
-        config.put(EmailSender.PROPERTY_MAIL_SMTP_AUTH, "true");
-        config.put(EmailSender.PROPERTY_MAIL_SMTP_STARTTLS_ENABLE, "true");
-        config.put(EmailSender.PROPERTY_MAIL_SMTP_SSL_TRUST, "all");
-
-        config.put(EXTRA_PROPERTY_MAIL_SMTP_CONNECTIONTIMEOUT, "120000");
-
-        EmailSender.Builder builder = new EmailSender.Builder(config.build());
-        assertThat(builder.getProperties().size()).isEqualTo(1);
-        assertThat(builder.getProperties().get(EXTRA_PROPERTY_MAIL_SMTP_CONNECTIONTIMEOUT)).isNotNull();
-
-        ImmutableMap.Builder<String, Serializable> props = ImmutableMap.builder();
-        props.put(EXTRA_PROPERTY_MAIL_SMTP_SSL_ENABLE, "from");
-        props.put(EXTRA_PROPERTY_MAIL_SMTP_CIPHERSUITES, "DHE_RSA_AES256_SHA256");
-        ImmutableMap resultProperties = props.build();
-        // Override the two previous properties
-        builder.withProperties(resultProperties);
-
-        ImmutableMap.Builder<String, Serializable> allExtraProperties = ImmutableMap.builder();
-        allExtraProperties.put(EXTRA_PROPERTY_MAIL_SMTP_SSL_ENABLE, "from");
-        allExtraProperties.put(EXTRA_PROPERTY_MAIL_SMTP_CIPHERSUITES, "DHE_RSA_AES256_SHA256");
-        allExtraProperties.put(EXTRA_PROPERTY_MAIL_SMTP_CONNECTIONTIMEOUT, "120000");
-
-        assertThat(builder.getProperties()).containsExactlyEntriesIn(allExtraProperties.build());
+        assertThat(builder.getProperties()).hasSize(10);
+        assertThat(builder.getProperties()).containsEntry(EXTRA_PROPERTY_MAIL_SMTP_SSL_ENABLE, "true");
+        assertThat(builder.getProperties()).containsEntry(EXTRA_PROPERTY_MAIL_SMTP_CONNECTIONTIMEOUT, "120000");
     }
 }

--- a/src/test/java/org/ow2/proactive/addons/email/EmailSenderBuilderTest.java
+++ b/src/test/java/org/ow2/proactive/addons/email/EmailSenderBuilderTest.java
@@ -219,7 +219,7 @@ public class EmailSenderBuilderTest {
         config.put(EXTRA_PROPERTY_MAIL_SMTP_CONNECTIONTIMEOUT, "120000");
 
         EmailSender.Builder builder = new EmailSender.Builder(config.build());
-        assertThat(builder.getProperties().size()).isEqualTo(1);
+        assertThat(builder.getProperties().size()).isEqualTo(9);
         assertThat(builder.getProperties().get(EXTRA_PROPERTY_MAIL_SMTP_CONNECTIONTIMEOUT)).isNotNull();
 
         ImmutableMap.Builder<String, Serializable> extraProps = ImmutableMap.builder();


### PR DESCRIPTION
Currently it is not possible to set an SMTP connexion property that is not declared in the EmailSender class.
Example: we cannot set a SSL connection to the SMTP server as the property "mail.smtp.ssl.enable" is not a field and parsed.

This PR enables the user to provide custom properties in the EmailSender.Builder constructor that will be set for the connection.
Also a "withProperty()" method that acts as setter for custom properties.